### PR TITLE
feat: Upgrade to GPT-4 model with increased token limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ You can customize the application by modifying `src/main/resources/application.p
 # Server port (default: 8080)
 server.port=8080
 
-# OpenAI model to use (default: gpt-3.5-turbo)
-openai.model=gpt-3.5-turbo
+# OpenAI model to use (default: gpt-4)
+openai.model=gpt-4
 
 # API key (can also be set via environment variable)
 openai.api.key=${OPENAI_API_KEY:}

--- a/src/main/java/com/example/aiagent/service/AiService.java
+++ b/src/main/java/com/example/aiagent/service/AiService.java
@@ -15,7 +15,7 @@ public class AiService {
     @Value("${openai.api.key:}")
     private String apiKey;
 
-    @Value("${openai.model:gpt-3.5-turbo}")
+    @Value("${openai.model:gpt-4}")
     private String model;
 
     private OpenAiService openAiService;
@@ -42,7 +42,7 @@ public class AiService {
             ChatCompletionRequest request = ChatCompletionRequest.builder()
                     .model(model)
                     .messages(List.of(message))
-                    .maxTokens(500)
+                    .maxTokens(1000)
                     .temperature(0.7)
                     .build();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ server.port=8080
 # OpenAI Configuration
 # Set your OpenAI API key here or use environment variable OPENAI_API_KEY
 openai.api.key=${OPENAI_API_KEY:}
-openai.model=gpt-3.5-turbo
+openai.model=gpt-4
 
 # Thymeleaf Configuration
 spring.thymeleaf.cache=false


### PR DESCRIPTION
- Change default model from gpt-3.5-turbo to gpt-4
- Increase max tokens from 500 to 1000 for better responses
- Update documentation to reflect GPT-4 usage
- Maintain backward compatibility with configurable model setting