### PR TITLE
feat: add chat history and context storage with H2 database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,18 @@
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
 
+        <!-- Database Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- OpenAI Client -->
         <dependency>
             <groupId>com.theokanning.openai-gpt3-java</groupId>

--- a/src/main/java/techchamps/io/aiagent/model/ChatMessage.java
+++ b/src/main/java/techchamps/io/aiagent/model/ChatMessage.java
@@ -1,12 +1,37 @@
 package techchamps.io.aiagent.model;
 
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
+@Entity
+@Table(name = "chat_messages")
 public class ChatMessage {
-    private String id;
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
+    
+    @Column(nullable = false)
     private String sender; // "user" or "assistant"
+    
+    @Column(nullable = false)
     private LocalDateTime timestamp;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_session_id", nullable = false)
+    private ChatSession chatSession;
+    
+    @Column(columnDefinition = "TEXT")
+    private String imageUrl;
+    
+    @Column(columnDefinition = "TEXT")
+    private String fileContent;
+    
+    @Column
+    private String fileName;
 
     public ChatMessage() {
         this.timestamp = LocalDateTime.now();
@@ -19,11 +44,11 @@ public class ChatMessage {
     }
 
     // Getters and Setters
-    public String getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(Long id) {
         this.id = id;
     }
 
@@ -49,5 +74,37 @@ public class ChatMessage {
 
     public void setTimestamp(LocalDateTime timestamp) {
         this.timestamp = timestamp;
+    }
+    
+    public ChatSession getChatSession() {
+        return chatSession;
+    }
+    
+    public void setChatSession(ChatSession chatSession) {
+        this.chatSession = chatSession;
+    }
+    
+    public String getImageUrl() {
+        return imageUrl;
+    }
+    
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+    
+    public String getFileContent() {
+        return fileContent;
+    }
+    
+    public void setFileContent(String fileContent) {
+        this.fileContent = fileContent;
+    }
+    
+    public String getFileName() {
+        return fileName;
+    }
+    
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
     }
 } 

--- a/src/main/java/techchamps/io/aiagent/model/ChatResponse.java
+++ b/src/main/java/techchamps/io/aiagent/model/ChatResponse.java
@@ -1,8 +1,13 @@
 package techchamps.io.aiagent.model;
 
+import java.util.List;
+
 public class ChatResponse {
     private String message;
     private String error;
+    private String sessionId;
+    private List<ChatMessage> messageHistory;
+    private String context;
 
     public ChatResponse() {
     }
@@ -30,5 +35,29 @@ public class ChatResponse {
 
     public void setError(String error) {
         this.error = error;
+    }
+    
+    public String getSessionId() {
+        return sessionId;
+    }
+    
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+    
+    public List<ChatMessage> getMessageHistory() {
+        return messageHistory;
+    }
+    
+    public void setMessageHistory(List<ChatMessage> messageHistory) {
+        this.messageHistory = messageHistory;
+    }
+    
+    public String getContext() {
+        return context;
+    }
+    
+    public void setContext(String context) {
+        this.context = context;
     }
 } 

--- a/src/main/java/techchamps/io/aiagent/model/ChatSession.java
+++ b/src/main/java/techchamps/io/aiagent/model/ChatSession.java
@@ -1,0 +1,139 @@
+package techchamps.io.aiagent.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "chat_sessions")
+public class ChatSession {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false)
+    private String sessionId;
+    
+    @Column(nullable = false)
+    private String title;
+    
+    @Column(columnDefinition = "TEXT")
+    private String context;
+    
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+    
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+    
+    @OneToMany(mappedBy = "chatSession", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<ChatMessage> messages = new ArrayList<>();
+    
+    @Column(nullable = false)
+    private String model;
+    
+    @Column(nullable = false)
+    private String imageModel;
+    
+    // Constructors
+    public ChatSession() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    public ChatSession(String sessionId, String title, String context, String model, String imageModel) {
+        this();
+        this.sessionId = sessionId;
+        this.title = title;
+        this.context = context;
+        this.model = model;
+        this.imageModel = imageModel;
+    }
+    
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getSessionId() {
+        return sessionId;
+    }
+    
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+    
+    public String getTitle() {
+        return title;
+    }
+    
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    
+    public String getContext() {
+        return context;
+    }
+    
+    public void setContext(String context) {
+        this.context = context;
+    }
+    
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+    
+    public List<ChatMessage> getMessages() {
+        return messages;
+    }
+    
+    public void setMessages(List<ChatMessage> messages) {
+        this.messages = messages;
+    }
+    
+    public String getModel() {
+        return model;
+    }
+    
+    public void setModel(String model) {
+        this.model = model;
+    }
+    
+    public String getImageModel() {
+        return imageModel;
+    }
+    
+    public void setImageModel(String imageModel) {
+        this.imageModel = imageModel;
+    }
+    
+    // Helper methods
+    public void addMessage(ChatMessage message) {
+        message.setChatSession(this);
+        this.messages.add(message);
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+} 

--- a/src/main/java/techchamps/io/aiagent/model/SessionRequest.java
+++ b/src/main/java/techchamps/io/aiagent/model/SessionRequest.java
@@ -1,74 +1,60 @@
 package techchamps.io.aiagent.model;
 
-public class ChatRequest {
-    private String message;
+public class SessionRequest {
     private String sessionId;
+    private String title;
     private String context;
     private String model;
     private String imageModel;
-    private String fileContent;
-    private String fileName;
 
-    public ChatRequest() {
+    public SessionRequest() {
     }
 
-    public ChatRequest(String message) {
-        this.message = message;
+    public SessionRequest(String sessionId, String title, String context, String model, String imageModel) {
+        this.sessionId = sessionId;
+        this.title = title;
+        this.context = context;
+        this.model = model;
+        this.imageModel = imageModel;
     }
 
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-    }
-    
     public String getSessionId() {
         return sessionId;
     }
-    
+
     public void setSessionId(String sessionId) {
         this.sessionId = sessionId;
     }
-    
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
     public String getContext() {
         return context;
     }
-    
+
     public void setContext(String context) {
         this.context = context;
     }
-    
+
     public String getModel() {
         return model;
     }
-    
+
     public void setModel(String model) {
         this.model = model;
     }
-    
+
     public String getImageModel() {
         return imageModel;
     }
-    
+
     public void setImageModel(String imageModel) {
         this.imageModel = imageModel;
-    }
-    
-    public String getFileContent() {
-        return fileContent;
-    }
-    
-    public void setFileContent(String fileContent) {
-        this.fileContent = fileContent;
-    }
-    
-    public String getFileName() {
-        return fileName;
-    }
-    
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
     }
 } 

--- a/src/main/java/techchamps/io/aiagent/model/SessionResponse.java
+++ b/src/main/java/techchamps/io/aiagent/model/SessionResponse.java
@@ -1,0 +1,91 @@
+package techchamps.io.aiagent.model;
+
+import java.util.List;
+
+public class SessionResponse {
+    private String sessionId;
+    private String title;
+    private String context;
+    private String model;
+    private String imageModel;
+    private List<ChatMessage> messages;
+    private String error;
+    private boolean success;
+
+    public SessionResponse() {
+    }
+
+    public SessionResponse(String sessionId, String title, String context, String model, String imageModel) {
+        this.sessionId = sessionId;
+        this.title = title;
+        this.context = context;
+        this.model = model;
+        this.imageModel = imageModel;
+        this.success = true;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public String getImageModel() {
+        return imageModel;
+    }
+
+    public void setImageModel(String imageModel) {
+        this.imageModel = imageModel;
+    }
+
+    public List<ChatMessage> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<ChatMessage> messages) {
+        this.messages = messages;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+        this.success = false;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+} 

--- a/src/main/java/techchamps/io/aiagent/repository/ChatMessageRepository.java
+++ b/src/main/java/techchamps/io/aiagent/repository/ChatMessageRepository.java
@@ -1,0 +1,21 @@
+package techchamps.io.aiagent.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import techchamps.io.aiagent.model.ChatMessage;
+
+import java.util.List;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatSession.sessionId = :sessionId ORDER BY cm.timestamp ASC")
+    List<ChatMessage> findBySessionIdOrderByTimestampAsc(@Param("sessionId") String sessionId);
+    
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatSession.sessionId = :sessionId ORDER BY cm.timestamp DESC")
+    List<ChatMessage> findBySessionIdOrderByTimestampDesc(@Param("sessionId") String sessionId);
+    
+    void deleteByChatSessionSessionId(String sessionId);
+} 

--- a/src/main/java/techchamps/io/aiagent/repository/ChatSessionRepository.java
+++ b/src/main/java/techchamps/io/aiagent/repository/ChatSessionRepository.java
@@ -1,0 +1,24 @@
+package techchamps.io.aiagent.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import techchamps.io.aiagent.model.ChatSession;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
+    
+    Optional<ChatSession> findBySessionId(String sessionId);
+    
+    @Query("SELECT cs FROM ChatSession cs ORDER BY cs.updatedAt DESC")
+    List<ChatSession> findAllOrderByUpdatedAtDesc();
+    
+    @Query("SELECT cs FROM ChatSession cs WHERE cs.title LIKE %:searchTerm% OR cs.context LIKE %:searchTerm% ORDER BY cs.updatedAt DESC")
+    List<ChatSession> findByTitleOrContextContaining(@Param("searchTerm") String searchTerm);
+    
+    void deleteBySessionId(String sessionId);
+} 

--- a/src/main/java/techchamps/io/aiagent/service/ChatSessionService.java
+++ b/src/main/java/techchamps/io/aiagent/service/ChatSessionService.java
@@ -1,0 +1,101 @@
+package techchamps.io.aiagent.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import techchamps.io.aiagent.model.ChatMessage;
+import techchamps.io.aiagent.model.ChatSession;
+import techchamps.io.aiagent.repository.ChatMessageRepository;
+import techchamps.io.aiagent.repository.ChatSessionRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Transactional
+public class ChatSessionService {
+    
+    @Autowired
+    private ChatSessionRepository chatSessionRepository;
+    
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+    
+    public ChatSession createSession(String title, String context, String model, String imageModel) {
+        String sessionId = UUID.randomUUID().toString();
+        ChatSession session = new ChatSession(sessionId, title, context, model, imageModel);
+        return chatSessionRepository.save(session);
+    }
+    
+    public Optional<ChatSession> getSession(String sessionId) {
+        return chatSessionRepository.findBySessionId(sessionId);
+    }
+    
+    public List<ChatSession> getAllSessions() {
+        return chatSessionRepository.findAllOrderByUpdatedAtDesc();
+    }
+    
+    public List<ChatSession> searchSessions(String searchTerm) {
+        return chatSessionRepository.findByTitleOrContextContaining(searchTerm);
+    }
+    
+    public ChatSession updateSessionContext(String sessionId, String context) {
+        Optional<ChatSession> optionalSession = chatSessionRepository.findBySessionId(sessionId);
+        if (optionalSession.isPresent()) {
+            ChatSession session = optionalSession.get();
+            session.setContext(context);
+            session.setUpdatedAt(LocalDateTime.now());
+            return chatSessionRepository.save(session);
+        }
+        throw new RuntimeException("Session not found: " + sessionId);
+    }
+    
+    public ChatSession updateSessionTitle(String sessionId, String title) {
+        Optional<ChatSession> optionalSession = chatSessionRepository.findBySessionId(sessionId);
+        if (optionalSession.isPresent()) {
+            ChatSession session = optionalSession.get();
+            session.setTitle(title);
+            session.setUpdatedAt(LocalDateTime.now());
+            return chatSessionRepository.save(session);
+        }
+        throw new RuntimeException("Session not found: " + sessionId);
+    }
+    
+    public ChatMessage addMessage(String sessionId, String content, String sender, String imageUrl, String fileContent, String fileName) {
+        Optional<ChatSession> optionalSession = chatSessionRepository.findBySessionId(sessionId);
+        if (optionalSession.isPresent()) {
+            ChatSession session = optionalSession.get();
+            ChatMessage message = new ChatMessage(content, sender);
+            message.setImageUrl(imageUrl);
+            message.setFileContent(fileContent);
+            message.setFileName(fileName);
+            session.addMessage(message);
+            chatSessionRepository.save(session);
+            return message;
+        }
+        throw new RuntimeException("Session not found: " + sessionId);
+    }
+    
+    public List<ChatMessage> getSessionMessages(String sessionId) {
+        return chatMessageRepository.findBySessionIdOrderByTimestampAsc(sessionId);
+    }
+    
+    public void deleteSession(String sessionId) {
+        chatSessionRepository.deleteBySessionId(sessionId);
+    }
+    
+    public List<ChatMessage> getRecentMessages(String sessionId, int limit) {
+        List<ChatMessage> allMessages = chatMessageRepository.findBySessionIdOrderByTimestampDesc(sessionId);
+        return allMessages.stream()
+                .limit(limit)
+                .sorted((m1, m2) -> m1.getTimestamp().compareTo(m2.getTimestamp()))
+                .toList();
+    }
+    
+    public String getSessionContext(String sessionId) {
+        Optional<ChatSession> session = chatSessionRepository.findBySessionId(sessionId);
+        return session.map(ChatSession::getContext).orElse("");
+    }
+} 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,5 +9,21 @@ openai.model=gpt-4
 # Thymeleaf Configuration
 spring.thymeleaf.cache=false
 
+# H2 Database Configuration
+spring.datasource.url=jdbc:h2:mem:aiagent
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+# JPA Configuration
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
 # Logging
-logging.level.com.example.aiagent=DEBUG 
+logging.level.com.example.aiagent=DEBUG
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE 


### PR DESCRIPTION
- Add JPA entities for ChatSession and ChatMessage
- Add repositories and service for session/context management
- Update AiService and ChatController for session-aware chat
- Add endpoints for session CRUD and search
- Configure H2 in-memory database and JPA
- All chat and context is now persisted in the database

Closes #chat-history #context-storage